### PR TITLE
Fixes #9, adding identifiable exceptions for parse/encode errors.

### DIFF
--- a/java/charred/CSVReader.java
+++ b/java/charred/CSVReader.java
@@ -50,7 +50,7 @@ public final class CSVReader {
       sb.append(buffer,startpos,len);
       buffer = reader.nextBuffer();
     }
-    throw new EOFException("EOF encountered within quote - " + sb.toString());
+    throw new EOFException("CSV parse error - EOF encountered within quote - " + sb.toString());
   }
   final void csvReadComment() throws EOFException {
     char[] buffer = reader.buffer();

--- a/java/charred/CharredException.java
+++ b/java/charred/CharredException.java
@@ -1,0 +1,10 @@
+package charred;
+
+
+import java.lang.Exception;
+
+public final class CharredException extends Exception {
+    public CharredException(String message) {
+	super(message);
+    }
+}

--- a/java/charred/JSONWriter.java
+++ b/java/charred/JSONWriter.java
@@ -113,17 +113,17 @@ public class JSONWriter implements AutoCloseable {
       final Double dn = (Double)n;
       if (!Double.isFinite(dn)) {
 	if (Double.isNaN(dn))
-	  throw new Exception("JSON encoding error - NAN detected");
+	  throw new CharredException("JSON encoding error - NAN detected");
 	else
-	  throw new Exception("JSON encoding error - +/-INF detected");
+	  throw new CharredException("JSON encoding error - +/-INF detected");
       }
     } else if (n instanceof Float) {
       final Float dn = (Float)n;
       if (!Float.isFinite(dn)) {
 	if (Float.isNaN(dn))
-	  throw new Exception("JSON encoding error - NAN detected");
+	  throw new CharredException("JSON encoding error - NAN detected");
 	else
-	  throw new Exception("JSON encoding error - +/-INF detected");
+	  throw new CharredException("JSON encoding error - +/-INF detected");
       }
     }
     w.write(n.toString());
@@ -186,7 +186,7 @@ public class JSONWriter implements AutoCloseable {
       Object k = val.getKey();
       Object v = val.getValue();
       if (! (k instanceof String) )
-	throw new Exception("JSON encoding error - Map keys must be strings");
+	throw new CharredException("JSON encoding error - Map keys must be strings");
       if (!first) {
 	w.write(",");
       }

--- a/src/charred/api.clj
+++ b/src/charred/api.clj
@@ -25,7 +25,7 @@
             [clojure.set :as set])
   (:import [charred CharBuffer CharReader CSVReader CSVReader$RowReader JSONReader
             JSONReader$ObjReader CloseableSupplier CSVWriter JSONWriter
-            JSONReader$ArrayReader]
+            JSONReader$ArrayReader CharredException]
            [java.util.concurrent ArrayBlockingQueue Executors ExecutorService ThreadFactory]
            [java.lang AutoCloseable]
            [java.util.function Supplier LongPredicate BiConsumer]
@@ -226,8 +226,8 @@
     (string? v)
     (do
       (when-not (== 1 (.length ^String v))
-        (throw (Exception.
-                (format "Only single character separators allowed: - \"%s\""
+        (throw (CharredException.
+                (format "CSV error - Only single character separators allowed: - \"%s\""
                         v))))
       (first v))
     (number? v)


### PR DESCRIPTION
Feel extremely free to use this as a jumping off point and/or throw out. That said I can also make further changes  (plenty of bandwidth this coming week).

Notes:

-Per your notes, went with library specific subclass, `CharredException`, with standardized string prefixes ("JSON parse error - ", "JSON  encoding error - ", "CSV parse error - ").

-It seemed logical to go beyond just parse errors into encode errors as well (there were not many).

-I did *not* change `EOFException`s to `CharredException`s. I only re-classed plain `Exception`s. I *did* add the standardized string prefixes to the messages of `EOFException`s where it seemed appropriate. My logic was that this is a specific enough subclass that people might already be testing for it - and also specific enough that the case for re-classing is weaker.

-I did *not* change any of the tests of the form `(is (thrown? Exception (read-json "foo")))` to be specific to `CharredException`.

-I did *not* switch to unchecked exceptions (`RuntimeException` subclass) since it seemed you were intentionally using checked exceptions (`Exception`) - `CharredException` subclasses the latter.

-I did *not* get fussy about standardizing capitalization of the first letter after the message string prefix - it's possible people are already doing case insensitive matching on the old messages.

-I did *not* get fussy about making the use of periods at the end of the message strings consistent (because this seemed extremely fussy!).

-Alternative approach: Some might argue that all the `CharredException`s could just be standard `IllegalArgumentException`s, which would be more specific than what you had before without requiring the custom subclass (plus they would have the standardized string prefixes in the message).

-Alternate approach: Conversely, you could make a custom exception bestiary, including `CharredEOFException`, `CharredParseException`, and `CharredEncodeException` (or similar), which would allow a reclassing of some of the  current `EOFException`s without the compatibility worries (since it could subclass `java.io.EOFException`).

I do not have strong opinions about any of the above, I just thought I'd note the issues/thoughts that came up.