### PR TITLE
Fix docstring for write-json to match code about :indent-str

### DIFF
--- a/src/charred/api.clj
+++ b/src/charred/api.clj
@@ -674,8 +674,8 @@ Defaults to toString for types that aren't representable in json."))
        false. (These two characters are valid in pure JSON but are not
        valid in JavaScript strings.
   * `:escape-slash` If true (default) the slash / is escaped as \\/
-  * `:indent-str` Defaults to \"  \".  When nil json is printed raw with no indent or
-     whitespace.
+  * `:indent-str` When nil (default) json is printed raw with no indent or whitespace. For
+      two spaces of indent per level of nesting, choose \"  \".
   * `:obj-fn` - Function called on each non-primitive object - it is passed the JSONWriter and
      the object.  The default iterates maps, lists, and arrays converting anything that is
      not a json primitive or a map, list or array to a json primitive via str.  java.sql.Date


### PR DESCRIPTION
Hi! First, thank you for charred! I absolutely love that I don't need to deal with jackson _and_ it's fast.

Today I came across a mismatch in docstring for `write-json` where it says the default is `"  "`, but in code it is actually `nil`. This PR amends the docs.

I'm happy to change the wording, if needed.