### PR TITLE
Fixes #31 regression introduced in 1.035

### DIFF
--- a/java/charred/JSONWriter.java
+++ b/java/charred/JSONWriter.java
@@ -112,8 +112,13 @@ public class JSONWriter implements AutoCloseable {
 
     while (idx < dlen) {
       final char c = data.charAt(idx);
+      final int cInt = (int) c;
 
-      if ((int) c < 128 && c != '"') {
+      if (cInt >= 32 && cInt < 128
+          && cInt != 34 // "
+          && cInt != 92 // \
+          && cInt != 47 // /
+        ) {
         ++idx;
       } else {
         break;

--- a/test/charred/json_test.clj
+++ b/test/charred/json_test.clj
@@ -16,6 +16,17 @@
   (is (= 3.14159 (charred/read-json "3.14159")))
   (is (= 6.022e23 (charred/read-json "6.022e23"))))
 
+(deftest regression-31
+  ;; [#31] Newlines no longer escaped in 1.035
+  (is (= 1
+         (->
+          (charred/write-json-str
+           {:some-key "new
+                     lines
+                     here"})
+          str/split-lines
+          count))))
+
 (deftest read-bigint
   (is (= 123456789012345678901234567890N
          (charred/read-json "123456789012345678901234567890"))))


### PR DESCRIPTION
Based on `code-point-decoder` we should not escape characters in the range of `[32-128)` which are not controls. Identified controls in this range are `"` (34), `\` (92) and `/` (47).

[data.json code-point-decoder implementation](https://github.com/clojure/data.json/blob/09d6fafb09462ab4c7f9a46e6a478f893907e529/src/main/clojure/clojure/data/json.clj#L579-L594)