### PR TITLE
fix typo in ->bi-consumer

### DIFF
--- a/src/charred/coerce.clj
+++ b/src/charred/coerce.clj
@@ -181,7 +181,7 @@
     (instance? BiConsumer item)
     item
     (instance? IFn item)
-    (reify BiConsumer (accept [this a1 a2] (item a2 a2)))
+    (reify BiConsumer (accept [this a1 a2] (item a1 a2)))
     :else
     (throw (Exception. (failed-coercion-message item "bi-consumer")))))
 


### PR DESCRIPTION
This typo prevents users from providing functions to the :obj-fn option (an exception is thrown when trying to treat the first param as a writer). Instead users must reify BiConsumer directly.